### PR TITLE
Add Taiwan holiday highlights to monthly calendar

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -31,7 +31,7 @@ async function fetchHolidaysForMonth(year, month) {
     }
     const monthData = {};
     allHolidays.forEach(item => {
-      if (item.date.startsWith(`${year}${month}`) && item.holidaycategory !== '星期六、星期日') {
+      if (item.date && item.date.startsWith(`${year}${month}`) && item.holidaycategory !== '星期六、星期日') {
         const formatted = `${item.date.slice(0,4)}-${item.date.slice(4,6)}-${item.date.slice(6,8)}`;
         monthData[formatted] = item;
       }

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,35 @@ const modalCORS = document.getElementById('modalCORS');
 const versionDisplay = document.getElementById('version-display');
 const airportSuggestionsContainer = document.getElementById('airportSuggestionsContainer'); // Added
 
+// Taiwan holiday API
+const TAIWAN_CALENDAR_API = 'https://opensheet.elk.sh/1yC_pjiP0orcMqRy0rpymMjDpISJhiJBcMoOmCowru84/taiwan-calendar';
+let allHolidays = null;
+const holidayCache = {};
+
+async function fetchHolidaysForMonth(year, month) {
+  const key = `${year}-${month}`;
+  if (holidayCache[key]) return holidayCache[key];
+  try {
+    if (!allHolidays) {
+      const res = await fetch(TAIWAN_CALENDAR_API);
+      allHolidays = await res.json();
+    }
+    const monthData = {};
+    allHolidays.forEach(item => {
+      if (item.date.startsWith(`${year}${month}`) && item.holidaycategory !== '星期六、星期日') {
+        const formatted = `${item.date.slice(0,4)}-${item.date.slice(4,6)}-${item.date.slice(6,8)}`;
+        monthData[formatted] = item;
+      }
+    });
+    holidayCache[key] = monthData;
+    return monthData;
+  } catch (err) {
+    console.error('Failed to fetch holidays:', err);
+    holidayCache[key] = {};
+    return {};
+  }
+}
+
 const options = airports.map(airport => {
   const regionStyle = regionStyles[airport.region];
   const flag = regionStyle?.flag || '🏳️'; // Default flag if region or style not found
@@ -273,7 +302,7 @@ function hideLoader() {
   loaderContainer.classList.add('hidden');
 }
 
-function searchFlight(departure, arrival, departureDate) {
+async function searchFlight(departure, arrival, departureDate) {
   const url = 'https://cors-anywhere.herokuapp.com/https://ecapi.starlux-airlines.com/searchFlight/v2/flights/calendars/monthly';
 
   // returnDate = departureDate + 5 days
@@ -326,35 +355,36 @@ function searchFlight(departure, arrival, departureDate) {
   showLoader();
   containerResult.classList.remove('hidden');
 
-  fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'jx-lang': 'zh-TW',
-    },
-    body: JSON.stringify(data)
-  })
-    .then(response => response.json())
-    .then(data => {
-      console.log(data);
-      // 在這裡使用 data 進行後續操作
-      renderFlightInfo(data);
-      hideLoader();
-    })
-    .catch(error => {
-      console.error('無法取得航班資訊:', error);
-      console.log(error);
+  try {
+    const flightPromise = fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'jx-lang': 'zh-TW',
+      },
+      body: JSON.stringify(data)
+    }).then(response => response.json());
 
-      // 若是 https://cors-anywhere.herokuapp.com/corsdemo 錯誤，提示需要到 https://cors-anywhere.herokuapp.com/corsdemo 啟用
-      if (error.message.includes('See /cors')) {
-        logError('請到 https://cors-anywhere.herokuapp.com/corsdemo 啟用 CORS');
-        modalCORS.classList.remove('hidden');
-      }
-      hideLoader();
-    });
+    const [year, month] = inputMonth.value.split('-');
+    const holidaysPromise = fetchHolidaysForMonth(year, month);
+
+    const [flightData, holidays] = await Promise.all([flightPromise, holidaysPromise]);
+    console.log(flightData);
+    renderFlightInfo(flightData, holidays);
+  } catch (error) {
+    console.error('無法取得航班資訊:', error);
+    console.log(error);
+
+    if (error.message.includes('See /cors')) {
+      logError('請到 https://cors-anywhere.herokuapp.com/corsdemo 啟用 CORS');
+      modalCORS.classList.remove('hidden');
+    }
+  } finally {
+    hideLoader();
+  }
 }
 
-function renderFlightInfo(data) {
+function renderFlightInfo(data, holidays = {}) {
   const calendars = data.data.calendars;
   const departure = selectAirportFrom.getAttribute('data-selected-value');
   const arrival = selectAirportTo.getAttribute('data-selected-value');
@@ -407,6 +437,8 @@ function renderFlightInfo(data) {
       const isWeekend = dayOfWeek === 0 || dayOfWeek === 6; // Check if it's Saturday or Sunday
       const month = String(date.getMonth() + 1).padStart(2, '0'); // 將月份格式化為兩位數
       const day = String(dayOfMonth).padStart(2, '0'); // 將月份格式化為兩位數
+      const holiday = holidays[calendar.departureDate];
+      const holidayBadge = holiday ? `<div class="absolute top-0 left-0 bg-red-600 text-white text-[10px] px-1 rounded-br" title="${holiday.name || holiday.holidaycategory}">${(holiday.name || holiday.holidaycategory).slice(0,4)}</div>` : '';
 
       // Calculate return date parts
       const returnDateObj = new Date(date);
@@ -419,6 +451,7 @@ function renderFlightInfo(data) {
       (lowPrice) && div.classList.add('fire', 'border-primary', 'border-2', 'border-l-8');
       (!available) && div.classList.add('opacity-30', 'cursor-not-allowed', 'select-none');
       div.innerHTML = `
+        ${holidayBadge}
         <div class="absolute top-0 right-0 p-1">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 fill-primary ${lowPrice ? 'block' : 'hidden'}">
             <path d="M7.493 18.5c-.425 0-.82-.236-.975-.632A7.48 7.48 0 0 1 6 15.125c0-1.75.599-3.358 1.602-4.634.151-.192.373-.309.6-.397.473-.183.89-.514 1.212-.924a9.042 9.042 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V2.75A.75.75 0 0 1 15 2a2.25 2.25 0 0 1 2.25 2.25c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H14.23c-.483 0-.964-.078-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23h-.777ZM2.331 10.727a11.969 11.969 0 0 0-.831 4.398 12 12 0 0 0 .52 3.507C2.28 19.482 3.105 20 3.994 20H4.9c.445 0 .72-.498.523-.898a8.963 8.963 0 0 1-.924-3.977c0-1.708.476-3.305 1.302-4.666.245-.403-.028-.959-.5-.959H4.25c-.832 0-1.612.453-1.918 1.227Z" />


### PR DESCRIPTION
## Summary
- fetch Taiwan holiday data and cache by month
- show holiday badges on flight price calendar without affecting layout
- load holiday data alongside flight search request

## Testing
- `node js/main.test.js` *(fails: Main functions not found; tests require browser environment)*

------
https://chatgpt.com/codex/tasks/task_e_689f277f0cac832ba1e0ae9c7e4d4e38